### PR TITLE
chore: sync global AI instructions and standardise shell script helpers

### DIFF
--- a/ai/global/agent-roles.instructions.md
+++ b/ai/global/agent-roles.instructions.md
@@ -1,0 +1,84 @@
+# Agent Role Definitions
+
+[Back to Global Instructions Index](index.md)
+
+Load when acting as a named agent. Routing table and model selection: [task-workflow.instructions.md](task-workflow.instructions.md).
+
+## Orchestrator
+
+- Prioritise `CHANGES_REQUESTED` PRs over new issues.
+- Determine work type and route via the routing table. Never implement directly.
+
+## Code Writer
+
+- Implement the GitHub issue: read all relevant instruction files, write production code and tests.
+- Do not commit, push, or update the changelog — hand off to Code Tester when done.
+
+## Code Tester
+
+- Run build and all tests after Code Writer or Code Fixer finishes.
+- Check coverage against `git diff origin/main...HEAD`.
+- On build failure, test failure, or uncovered code: report file paths/line ranges to Code Writer — stop, do not proceed.
+- Loop with Code Writer until build passes, all tests pass, and all new/changed code is covered.
+- Do not modify code or tests — report and verify only.
+
+## Code Reviewer
+
+- Run `git diff origin/main...HEAD`, check every changed file against all instruction rules.
+- Launch three sub-agents **in parallel**: **Reuse** (duplicate utilities), **Quality** (redundant state, copy-paste, leaky abstractions), **Efficiency** (unnecessary work, missed concurrency, hot-path bloat).
+- Fix each real finding in its own commit; skip false positives. Re-run Code Tester after fixes.
+- Report `{"clean": true}` or `{"clean": false, "fixes": [...]}`. Cap at 5 iterations.
+
+## Code Fixer
+
+- Address requested changes on an existing PR — this includes both GitHub `CHANGES_REQUESTED` review status and verbal/chat requests for changes on an open PR.
+- Convert to draft before starting (`gh pr ready <number> --undo`).
+- One commit per review comment. Hand off to Code Tester after each fix.
+- Respond to **every** review comment without exception:
+  - If the comment required a code change: reply with `Fixed in <commit-sha>`.
+  - If the comment is a question or discussion point (no code change needed): reply with a full answer inline on the PR.
+
+## Rebase Agent
+
+- Rebase the named branch onto `origin/main`.
+- CHANGELOG conflicts: keep entries from both sides.
+- Any other conflict: report verbatim to Orchestrator — do not resolve.
+- Force-push with `--force-with-lease` only after all conflicts are resolved.
+
+## CI Debugger
+
+- Read full logs (`gh run view --log-failed`), identify root cause.
+- Fix if code-related; escalate with a clear description if environmental or infrastructure.
+
+## Changelog
+
+- Run after Code Tester and Code Reviewer are satisfied — never before.
+- Read `git diff origin/main...HEAD`, add entries via `dotnet changelog` (see [changelog.instructions.md](changelog.instructions.md)) — never edit `CHANGELOG.md` manually.
+- Do not commit (Committer's job) or run build/tests (Code Tester's job).
+
+## Committer
+
+- Use `git` CLI only — never `gh` or the GitHub API for commit/push.
+- Verify git identity and GPG signing before any commit (see [git.instructions.md](git.instructions.md#git-identity-check-mandatory-before-any-commit)). Stop and report if either check fails.
+- Commit code+tests as one GPG-signed commit (Conventional Commits, original prompt in body as `Prompt: …`).
+- Commit `CHANGELOG.md` as a separate GPG-signed commit.
+- Push immediately after. Do not open the PR — that is PR Submitter's job.
+- Do not use `--no-verify`. If a pre-commit hook fails: capture output, report to the producing agent, re-stage and retry. Escalate after 3 failed cycles.
+
+## PR Submitter
+
+- Run after Committer has pushed.
+- Wait up to 1 minute for GitHub to auto-create a PR (`gh pr list --head <branch>`); create one if absent.
+- Title: Conventional Commits format matching the primary commit. Body: summary + `Closes #<n>` (or `Related to #<n>`).
+- Update body if PR already exists. Add yourself as assignee.
+- Mark ready (`gh pr ready <number>`) only if Code Tester and Code Reviewer signed off — rebase first (`git fetch origin && git rebase origin/main`). Otherwise leave as draft.
+
+## CI Monitor _(not currently enabled)_
+
+- Watch checks after PR is ready: `gh pr checks <number> --watch`.
+- All pass → done. Any fail → hand off to CI Debugger. Repeat until all pass or CI Debugger escalates.
+
+## Dependency Updater
+
+- Review Dependabot PRs: auto-merge safe patch/minor bumps with no advisories and passing CI.
+- Flag major version bumps and breaking changes to the user. Never merge on CI failure or major bump without confirmation.

--- a/ai/global/api.instructions.md
+++ b/ai/global/api.instructions.md
@@ -1,0 +1,9 @@
+# API Instructions
+
+> Load when: an HTTP API is being created, consumed, or modified.
+
+[Back to Global Instructions Index](index.md)
+
+## HTTP Test Files
+
+- Every API endpoint (exposed or consumed) must have a corresponding `.http` test file: `<service>.http` for services you expose, `<api>.http` for APIs you consume.

--- a/ai/global/changelog.instructions.md
+++ b/ai/global/changelog.instructions.md
@@ -1,0 +1,34 @@
+# Changelog Instructions
+
+[Back to Global Instructions Index](index.md)
+
+Load this file when adding changelog entries or acting as the Changelog agent.
+
+## Rules
+
+- Use `Credfeto.Changelog.Cmd` — never edit `CHANGELOG.md` manually.
+- `CHANGELOG.md` must be listed in `.markdownlintignore` at the repo root (create the file if absent).
+- Entries must describe what changed and why it matters — not how it was implemented.
+
+## When to Skip
+
+Do **not** add an entry if:
+
+- The repository name contains `-template` (e.g. `credfeto/cs-template`) — kept blank for template consumers.
+- The change is documentation-only with no effect on production code.
+- The change is to AI instruction files.
+
+## Commands
+
+```bash
+# Add
+dotnet changelog -f CHANGELOG.md -a <Type> -m "<message>"
+
+# Remove
+dotnet changelog -f CHANGELOG.md -r <Type> -m "<exact message to remove>"
+
+# Help
+dotnet changelog --help
+```
+
+Valid types: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`, `Deployment Changes`

--- a/ai/global/code-quality.instructions.md
+++ b/ai/global/code-quality.instructions.md
@@ -1,0 +1,73 @@
+# Code Quality Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## Code Coverage
+
+- 100% code coverage must be maintained.
+- Test organisation in non-.NET projects is detailed in local AI instructions.
+
+## Pre-Commit
+
+- Write unit tests before every commit — every new behaviour must have corresponding tests.
+- See [git.instructions.md](git.instructions.md) for mandatory build and test verification before committing.
+
+## Dead Code
+
+- Remove unreachable code rather than writing tests around it.
+- Dead/unreachable code removal: separate commit from test changes, after running tests on the entire handler or app; one method or function per commit.
+- Shared code removal: only after the entire codebase has 100% coverage; each removal is its own commit.
+
+## Asynchronous Code
+
+- Prefer async over sync wherever supported.
+- Never block on async operations — always await or use async continuations.
+- Propagate async through the call stack — no synchronous wrappers around async operations.
+
+## Immutability
+
+Prefer immutable objects wherever possible — especially in async and multi-threaded code. Only break this for performance reasons when explicitly requested; note the reason in a comment.
+
+## Parameterised Tests
+
+Prefer parameterised tests over duplicated test methods — each behavioural variant is a data point, not a separate method. Use the idiomatic mechanism for the framework (xUnit `[Theory]`/`[InlineData]`, JUnit `@ParameterizedTest`, pytest `parametrize`, Jest `it.each`).
+
+## Test Quality
+
+- Tests must meet the same code quality standards as production code.
+- Test behaviour, not implementation — refactoring production code must not unnecessarily break tests.
+- Use constants, builders, or factory helpers rather than hardcoded values likely to change.
+
+## Refactoring
+
+- Review code after writing and testing to determine whether refactoring is needed.
+- Refactoring must be a separate commit from feature/fix changes.
+- Tests must pass after every refactoring commit.
+
+## Compile-Time Configuration
+
+Cover compile-time configuration (environment constants, build-time feature flags) with unit tests — not runtime assertions, which pollute production code.
+
+## Deprecation Warnings During Tests
+
+When deprecation warnings appear in test output (e.g. framework or runtime warnings about deprecated APIs):
+
+- **If the warning is new and caused by your change** — fix the deprecation before committing; do not leave it for later.
+- **If the warning is pre-existing and not caused by your change** — first check for an existing open GitHub issue in the current repository covering the same warning (for example by searching for the deprecated API, the warning text, and the affected component or dependency).
+  - If a matching open issue already exists, update it with any new context you found or reference it in your work; do not create a duplicate issue.
+  - If no matching open issue exists, raise a new GitHub issue in the current repository with:
+    - A clear title describing the deprecated API.
+    - The full warning text.
+    - The component or dependency responsible.
+    - What needs to be done to resolve it.
+    - Label the issue `AI-Work`.
+
+Do not suppress or ignore deprecation warnings.
+
+## Code Complexity
+
+- Prefer clean code — readable, well-named, single-responsibility.
+- Cyclomatic complexity must stay below 20 per method; refactor if it exceeds this.
+- Keep cognitive complexity low — if a method is hard to read at a glance, simplify it.
+- Prefer weak (static) connascence (Name, Type, Meaning) over strong (dynamic) forms (Execution, Timing, Identity) — see [connascence.io](https://connascence.io/).
+- Where stronger connascence is unavoidable, keep it local (within a single method or class).

--- a/ai/global/documentation.instructions.md
+++ b/ai/global/documentation.instructions.md
@@ -1,0 +1,18 @@
+# Documentation Instructions
+
+> Load when: writing code, documentation, comments, or commit messages.
+
+[Back to Global Instructions Index](index.md)
+
+## README
+
+- Keep `README.md` accurate and up to date; rewrite template placeholder content before starting work.
+- Include where applicable: CI badges (debug + release), links to `docs/`, build instructions, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`.
+- Update the configuration section in the same commit whenever a config option (`appsettings.json`, options class, or env var) is added, removed, or renamed — include type, default, and description.
+- For changelog format and tooling see [changelog.instructions.md](changelog.instructions.md).
+
+## Additional Documentation
+
+- All repos except `credfeto/cs-template` must have a `docs/` folder; that repo must not.
+- Place all docs and architecture diagrams (except `README.md`/`CHANGELOG.md`) in `docs/`; keep them current.
+- Architecture diagrams: show folder structure only — omit individual files and package versions; prefer SVG over raster formats.

--- a/ai/global/dotnet.examples.md
+++ b/ai/global/dotnet.examples.md
@@ -1,0 +1,31 @@
+# .NET Examples
+
+[Back to .NET Instructions](dotnet.instructions.md) | [Back to Global Instructions Index](index.md)
+
+Load this file when writing DI setup tests deriving from `DependencyInjectionTestsBase`.
+
+## Registering Mocked Services
+
+Use `.AddMockedService<T>()` instead of concrete inner classes or `Substitute.For<T>()`:
+
+```csharp
+// ✅ Correct
+private static IServiceCollection Configure(IServiceCollection services)
+{
+    return services.AddMyModule()
+                   .AddMockedService<IFoo>()
+                   .AddMockedService<IBar>();
+}
+```
+
+## Registering Mocked IOptions\<T\>
+
+Use `.AddMockedService<IOptions<TOptions>>(static o => o.Value.Returns(new TOptions()))`:
+
+```csharp
+// ✅ Correct
+.AddMockedService<IOptions<MyOptions>>(static o => o.Value.Returns(new MyOptions()))
+
+// ❌ Wrong
+.AddSingleton<IOptions<MyOptions>>(Options.Create(new MyOptions()))
+```

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -1,0 +1,123 @@
+# .NET Instructions
+
+> Load when: any `.csproj`, `.sln`, or `.slnx` file is present.
+
+[Back to Global Instructions Index](index.md)
+
+## NuGet Configuration (MANDATORY)
+
+- Never modify `nuget.config` — it is managed by the repo owner, not by AI.
+
+## Running .NET Tools (MANDATORY)
+
+- Always invoke dotnet tools via `dotnet <toolname>` (e.g. `dotnet changelog`, `dotnet buildcheck`).
+- Never search for the tool binary, add it to `PATH`, or invoke it directly as `~/.dotnet/tools/toolname` or similar.
+
+## Build and Test Before Commit (MANDATORY)
+
+Run `dotnet build` and `dotnet test` before every commit — see [git.instructions.md](git.instructions.md#build-and-test-verification-mandatory-before-any-commit-or-push).
+
+## Source-Generated Logging
+
+- Prefer `LoggerMessage` source generators over runtime string-based logging — faster, allocation-free, and compile-time structured.
+- Logging methods must be in a dedicated `internal static` class:
+  - Placed in a `LoggingExtensions` sub-namespace relative to the class it serves.
+  - Named `<ClassName>LoggingExtensions` (e.g. `FooLoggingExtensions` for `Foo`).
+
+## Asynchronous Code
+
+See [code-quality.instructions.md](code-quality.instructions.md) for general async rules. .NET-specific:
+
+- Prefer `ValueTask`/`ValueTask<T>` over `Task`/`Task<T>` — avoids heap allocations on synchronous-completion paths.
+- Only use `Task`/`Task<T>` where `ValueTask` is unsupported or the method always completes asynchronously.
+
+## Cancellation
+
+- All async methods must accept and pass down a `CancellationToken`.
+- Never create a new `CancellationToken` when one has been provided, unless combining with a timeout via `CancellationTokenSource.CreateLinkedTokenSource`.
+- Prefer overloads that accept a `CancellationToken`.
+- Do not pass `CancellationToken.None` without explicit documented reason.
+
+## Project and Solution Structure
+
+- All projects must be added to the solution file (`.slnx` or `.sln`).
+- All projects must pass `FunFair.BuildCheck` before committing: `dotnet buildcheck` (run from solution root; `dotnet buildcheck --help` for options).
+
+## Test Assembly Naming
+
+| Test type | Assembly name pattern |
+| --------- | --------------------- |
+| Unit tests | `<AssemblyName>.Tests` |
+| Integration tests | `<AssemblyName>.Integration.Tests` |
+| Benchmarks | `<AssemblyName>.Benchmark.Tests` |
+
+## Test Dependencies
+
+- All test projects must reference the latest release of `FunFair.Test.Common`.
+- All test projects must import the latest release of `FunFair.Test.Source.Generator`.
+- All test projects must include `<Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')" />`.
+- Test fixture classes must derive from `FunFair.Test.Common.TestBase`.
+
+## Benchmark Guidance
+
+- For .NET benchmark implementation and threshold assertions, follow [performance.instructions.md](performance.instructions.md#benchmarks-and-optimisation).
+
+## NSubstitute and FunFair.Test.Common Patterns
+
+| Instead of | Use |
+| ---------- | --- |
+| `Substitute.For<IMyInterface>()` | `GetSubstitute<IMyInterface>()` (static — no `this.`) |
+| `Substitute.For<ILogger<MyClass>>()` | `this.GetTypedLogger<MyClass>()` (instance — requires `this.`) |
+
+- Never call `Substitute.For<T>()` in classes deriving from `TestBase` or `DependencyInjectionTestsBase`.
+- Remove unused `using NSubstitute;` after replacing all `Substitute.For<>()` calls.
+
+## DI Setup Test Patterns
+
+Use `AddMockedService<T>()` in tests deriving from `DependencyInjectionTestsBase` — see [dotnet.examples.md](dotnet.examples.md) for `AddMockedService` and `IOptions` patterns.
+
+- Never create concrete no-op inner classes to satisfy DI mocking.
+- `GetSubstitute<T>()` is safe in `static` Configure methods.
+
+## Source File Organisation
+
+- One type per file — class, record, struct, interface, or enum.
+- File name must match the type name exactly (e.g. `FooBar.cs` for `class FooBar`).
+
+## Value Types (struct / record struct)
+
+- Prefer `struct` or `record struct` over `class` for small, short-lived, immutable data — avoids heap allocations.
+- Use `struct` when: the type is logically a value (not an identity), is generally small, and is frequently created/discarded.
+- Prefer `readonly struct` or `readonly record struct` to enforce immutability and enable compiler optimisations.
+- Avoid mutable structs — unexpected copy semantics cause subtle bugs.
+- Do not use `struct` for types that need inheritance or will be boxed frequently.
+
+## Debugger Diagnostics
+
+- All value types (`struct`, `record struct`, records with positional parameters) must have `[DebuggerDisplay("...")]` showing key fields.
+- All configuration/options classes must have `[DebuggerDisplay("...")]` showing key properties.
+
+## Time Abstraction
+
+- Use `System.TimeProvider` (.NET 8+) for all time abstractions.
+- Never use `Credfeto.Date.ICurrentTimeSource` or `FunFair.Common.Services.IDateTimeSource` — these are obsolete.
+- In tests, use `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` — never roll a custom mock.
+- Migrate any code touching `ICurrentTimeSource` or `IDateTimeSource` to `TimeProvider`/`FakeTimeProvider` as part of that work.
+
+## Warning Suppression and Errors
+
+- Every project must build with `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`.
+- Never use `#pragma warning disable <ID>`, `<NoWarn>`, `<WarningsNotAsErrors>`, or `[SuppressMessage]` without **explicit written permission from the repo owner**. Exception: per-advisory NuGet audit suppressions (see below).
+- If a warning fires, fix the root cause. If the fix is non-obvious, raise a GitHub issue rather than suppressing the warning.
+- Test projects are **not** exempt from this rule — suppressing warnings in test code is equally prohibited without explicit permission.
+
+## NuGet Vulnerability Suppression
+
+Suppress per-project using the advisory URL — never globally in shared `.props` files. Track each suppression in a GitHub issue.
+
+```xml
+<ItemGroup>
+  <!-- Reason: <why accepted> -->
+  <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xxxx-xxxx-xxxx" />
+</ItemGroup>
+```

--- a/ai/global/error-handling.instructions.md
+++ b/ai/global/error-handling.instructions.md
@@ -1,0 +1,24 @@
+# Error Handling Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## General Principles
+
+- All errors must be handled explicitly — never swallow exceptions or silently ignore error states.
+- Unhandled errors must not be allowed to crash a service or leave the system in an inconsistent state.
+
+## Catching Errors
+
+- Only catch errors you can meaningfully handle at that point — do not catch broadly just to suppress errors.
+- If an error cannot be handled locally, let it propagate to a level that can handle it, or wrap it in a more contextual error and rethrow.
+- Never catch an error, log it, and then rethrow it — this leads to duplicate log entries; either handle it or rethrow it.
+
+## Propagation
+
+- Errors should carry enough context to be diagnosable — include relevant identifiers, inputs, or state when wrapping errors.
+- Do not lose the original cause when wrapping errors; always chain or preserve the root cause.
+
+## Surfacing
+
+- Errors that are exposed to external callers (e.g. API responses) must be sanitised — do not leak internal implementation details, stack traces, or sensitive data in error responses.
+- Use appropriate error codes or status indicators for the protocol in use (e.g. HTTP status codes for REST APIs).

--- a/ai/global/git-commits.instructions.md
+++ b/ai/global/git-commits.instructions.md
@@ -1,0 +1,27 @@
+# Git Commit Instructions
+
+[Back to Global Instructions Index](index.md)
+
+Load this file when about to commit or acting as the Committer agent. See [git.instructions.md](git.instructions.md) for the mandatory identity check and branch verification.
+
+## Commit Rules
+
+- **Never create an empty commit.** Verify `git diff --cached --name-only` lists at least one file before running `git commit`.
+- Never amend an existing commit — always create a new one.
+- Push to `origin` after every commit.
+
+## Unexpected Reformatting During Commit (MANDATORY)
+
+If hooks or formatters modify files **not in your intended change set**:
+
+1. Do not stage the unrequested changes.
+2. Abort the commit.
+3. Report the affected files and which hook/formatter changed them.
+4. Wait for explicit instructions.
+
+Do not use `--no-verify`.
+
+## Commit Message Format
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+- Include the user's original prompt verbatim in the commit body, prefixed with `Prompt:` followed by a space — not in the title.

--- a/ai/global/git.examples.md
+++ b/ai/global/git.examples.md
@@ -1,0 +1,60 @@
+# Git Examples
+
+[Back to Git Instructions](git.instructions.md) | [Back to Global Instructions Index](index.md)
+
+## Git Identity Check Script
+
+Run before any commit to verify identity and GPG signing:
+
+```bash
+#!/bin/sh
+# Checks that git is configured with a valid identity and GPG signing.
+
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*"
+    exit 1
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
+CURRENT_EMAIL=$(git config user.email)
+
+[ -z "$CURRENT_EMAIL" ] && die "git user.email is not set — run: git config --global user.email \"you@example.com\""
+
+[ "$CURRENT_EMAIL" = "andy@nanoclaw.ai" ] && die "git is configured with the wrong identity (${CURRENT_EMAIL}) — aborting"
+
+[ "$(git config commit.gpgsign)" = "true" ] || die "GPG signing is not enabled — run: git config --global commit.gpgsign true"
+
+command -v gpg > /dev/null 2>&1 || die "gpg is not installed — cannot verify signing key"
+
+gpg --list-secret-keys "$CURRENT_EMAIL" > /dev/null 2>&1 \
+    || die "no GPG secret key found for ${CURRENT_EMAIL} — run: gpg --gen-key"
+
+SIGNING_KEY=$(git config user.signingkey)
+[ -z "$SIGNING_KEY" ] && die "git user.signingkey is not set — run: git config --global user.signingkey <keyid>"
+
+gpg --list-secret-keys "$SIGNING_KEY" > /dev/null 2>&1 \
+    || die "git user.signingkey (${SIGNING_KEY}) not found in GPG keyring"
+
+gpg --list-secret-keys "$SIGNING_KEY" 2>/dev/null | grep -qF "$CURRENT_EMAIL" \
+    || die "git user.signingkey (${SIGNING_KEY}) is not associated with ${CURRENT_EMAIL}"
+
+info "git identity check passed (${CURRENT_EMAIL}, key ${SIGNING_KEY})"
+```
+
+## Template Rule Escalation — Issue Command
+
+```bash
+gh issue create --repo credfeto/cs-template \
+  --title "<short description of the rule change>" \
+  --label "AI-Work" \
+  --body "**Source repository**: <repo where need was discovered>
+
+**Current behaviour / gap**: <what is missing or inconsistent>
+
+**Proposed rule text**: <concrete rule update or new instruction text>
+
+**Reason for template propagation**: <why this should apply across all repos>"
+```

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -1,0 +1,99 @@
+# Git Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## Language/Runtime Prerequisites (MANDATORY before any work)
+
+Verify all required languages and runtimes are installed. If any are missing, stop — do not scaffold code or make partial changes; ask the user to install them first.
+
+## Missing CLI Tools (MANDATORY)
+
+If a required CLI tool is not found, **stop immediately and ask the user to install it**. Never:
+
+- Search for the binary in alternative locations
+- Manipulate PATH to try to find it
+- Attempt to install it without being asked
+
+## Environment Health (MANDATORY)
+
+If the environment is too broken to work in without first fixing infrastructure or tooling, **stop** and demand it be fixed. Do not work around broken tooling.
+
+## Build and Test Verification (MANDATORY before any commit or push)
+
+Build must pass and all tests must pass before committing or pushing. If they fail and cannot be resolved, stop and ask.
+
+## Git Identity Check (MANDATORY before any commit)
+
+Before any commit, verify identity and GPG signing are correct — see [git.examples.md](git.examples.md) for the check script.
+
+**If either check fails: stop all work, do not commit, and report the misconfiguration.**
+
+## Pre-Commit Branch Check
+
+- Run `git branch --show-current` and confirm it is the expected working branch before staging or committing.
+- Never commit if the current branch is `main`.
+- If the branch has switched to `main` and the upstream no longer exists (merged and deleted), create a new branch before continuing.
+
+## GitHub Issues
+
+- If `gh` is available, use it to manage issues for every piece of work.
+- Before starting, either find a **100% matching** existing issue (confirm with user before linking) or create a new one with the original prompt and a clear description.
+- For complex or multi-component tasks, see [task-workflow.instructions.md](task-workflow.instructions.md).
+- Reference issue numbers in commit messages and branch names.
+- If work on an issue is abandoned, comment with findings before closing — do not abandon silently.
+
+## GitHub CLI (`gh`) Proxy Behavior
+
+When `GH_HOST` is set to a value other than `github.com`, `gh` routes through a proxy:
+
+- If a `gh` command fails, raise an issue on `credfeto/github-api-proxy` with the exact subcommand and flags, the API method (if visible), and the full error message.
+- Commit and push operations are always rejected by the proxy — use `git` CLI directly for all commit and push operations.
+
+## Running Git Commands in a Specific Directory
+
+- Never use `cd <dir> && git <command>` — use `git -C <dir> <command>` instead.
+
+## Branching
+
+- All new work must be in a branch — never commit directly to `main`.
+- Ensure `main` is up-to-date with `origin` before starting.
+- Continue in the same branch until the task changes.
+- Before continuing work on an existing branch, check if `origin/main` has advanced — if so, rebase first.
+
+## Branch Naming
+
+Format: `<type>/<name>` (mirroring Conventional Commits types):
+
+- `feature/add-user-auth`
+- `fix/null-pointer-on-login`
+- `chore/update-dependencies`
+- `refactor/simplify-payment-flow`
+
+Include the issue number when applicable: `fix/123-null-pointer-on-login`.
+
+For branches fixing multiple issues, reference each issue number in the individual commit message bodies.
+
+## Commits
+
+See [git-commits.instructions.md](git-commits.instructions.md) — load when about to commit.
+
+## Dependabot Vulnerability Warnings
+
+After any push, if the remote reports vulnerabilities:
+
+- Check for open Dependabot PRs covering them (`gh pr list --label dependencies`).
+- If none exist, visit the repo's Dependabot page and for any manually fixable advisory create a GitHub issue labelled `Security` and `AI-Work`, naming the package, severity, and fix steps.
+
+## Pre-Commit Hook Known Incompatibilities
+
+- **dotenv-linter**: use `entry: dotenv-linter check` — v3.x requires the `check` subcommand before the filename.
+
+## Template Rule Escalation (Non-Template Repos Only)
+
+When working outside `credfeto/cs-template` and a gap in the global template rules is found:
+
+1. Do not apply the change locally.
+2. Create an issue in `credfeto/cs-template` — see [git.examples.md](git.examples.md) for the command template.
+3. The issue must include: source repository, current behaviour/gap, proposed rule text, reason for template propagation.
+4. Note the issue URL in any relevant commit or PR description.
+5. Continue work without waiting for the template issue to be resolved.

--- a/ai/global/github-workflows.examples.md
+++ b/ai/global/github-workflows.examples.md
@@ -1,0 +1,114 @@
+# GitHub Workflows Examples
+
+[Back to GitHub Workflows Instructions](github-workflows.instructions.md) | [Back to Global Instructions Index](index.md)
+
+Load this file when creating or scaffolding a new local composite action.
+
+## Minimal Composite Action Template
+
+```yaml
+name: "Action Name"
+description: "What it does"
+
+inputs:
+  my-input:
+    description: "..."
+    required: true
+
+outputs:
+  my-output:
+    description: "..."
+    value: ${{steps.the-step.outputs.my-output}}
+
+runs:
+  using: composite
+  steps:
+    - name: "Do Thing"
+      id: the-step
+      uses: actions/github-script@v9.0.0
+      env:
+        MY_INPUT: ${{inputs.my-input}}
+      with:
+        script: |
+          // use process.env.MY_INPUT, not ${{inputs.my-input}}, in the script body
+          core.setOutput('my-output', result);
+```
+
+## Explicit Inputs Declaration
+
+Declare every required value as a named input with `required: true`:
+
+```yaml
+# action.yml
+inputs:
+  github-token:
+    description: "GitHub token with write access"
+    required: true
+  pr-number:
+    description: "Pull request number"
+    required: true
+```
+
+```yaml
+# caller
+uses: ./.github/actions/my-action
+with:
+  github-token: ${{secrets.SOURCE_PUSH_TOKEN}}
+  pr-number: ${{github.event.pull_request.number}}
+```
+
+## Env-Var Validation Step
+
+When env vars cannot be avoided, add this as the **first step** in the action:
+
+```yaml
+    - name: "Validate Environment"
+      uses: actions/github-script@v9.0.0
+      with:
+        script: |
+          const required = ['DOTNET_VERSION', 'NUGET_FEED'];
+          const missing = required.filter(k => !process.env[k]);
+          if (missing.length) {
+            core.setFailed(`❌ Required environment variables are not set: ${missing.join(', ')}`);
+          } else {
+            core.info('✅ All required environment variables are set');
+          }
+```
+
+## Step Output Formatting — github-script
+
+```javascript
+core.info(`✅ Branch ${branchName} already exists`);
+core.info(`✅ Updated global.json to version ${version}`);
+core.info(`❌ Branch ${branchName} not found — creating`);
+core.setFailed(`❌ Found ${mergeCommits.length} merge commit(s). Please rebase.`);
+core.warning(`⚠️ No releases found — nothing to do`);
+```
+
+## Step Output Formatting — bash
+
+```bash
+echo "✅ No merge conflict markers found."
+echo "❌ Merge conflict markers found — resolve before merging."
+echo "✅ src/global.json found — detected SDK version: $version"
+echo "⚠️ src/global.json not found — using fallback version: 10.0.*"
+```
+
+## Surfacing Key Values (core.info + core.notice)
+
+```javascript
+// \u001b[38;5;6m = ANSI 256-colour cyan; colours the value in the step log
+// core.notice surfaces it as a job annotation visible in the run summary
+core.info(`Version: \u001b[38;5;6m${version}`);
+core.notice(`Version: ${version}`);
+```
+
+## Unifying Invocations — Caller Pattern
+
+```yaml
+# pull_request trigger — PR is the current event
+pr-number: ${{github.event.pull_request.number}}
+
+# push trigger — PR was just created by a previous step
+pr-number: ${{steps.open-pr.outputs.pr_number}}
+```

--- a/ai/global/github-workflows.instructions.md
+++ b/ai/global/github-workflows.instructions.md
@@ -1,0 +1,255 @@
+# GitHub Workflows Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## Third-Party Action Policy
+
+Classify every `uses:` reference before adding or reviewing:
+
+- **Always allowed**: `actions/*` and `github/*`
+- **Convert to github-script or local action**: all other third-party actions
+- **Acceptable as-is**: actions requiring specialised external tooling not expressible via the GitHub API or bash — see [Cannot Convert](#actions-that-cannot-be-converted)
+
+When encountering existing third-party actions (including `credfeto/*`), replace with local equivalents where practical.
+
+## Converting to github-script (wrap in local composite action)
+
+Use `actions/github-script` to replace actions that:
+
+- Read a file from the workspace
+- Create, find, approve, or merge a pull request
+- Delete a branch
+- Add or sync labels on a PR or issue
+- Assign a user to a PR or issue
+- Enable auto-merge on a PR (via GraphQL)
+- Check PR commits for merge commits
+- Check repository visibility (public vs private)
+
+Wrap the `actions/github-script` step in a **local composite action** at `.github/actions/<name>/action.yml` — never inline the script in workflow files.
+
+The local action must:
+
+- Mirror inputs and outputs of the replaced action so callers only change the `uses:` line
+- Use `runs.using: composite`
+- Pin `actions/github-script` to a specific version (e.g. `@v9.0.0`)
+- Pass file paths or user-controlled strings via `env:` rather than string-interpolating into the `script:` body
+
+### Minimal local action template
+
+See [github-workflows.examples.md](github-workflows.examples.md) for the composite action scaffold, explicit inputs declaration, and env-var validation step template.
+
+## Simple Bash Replacements
+
+Replace these with a bash step — no `github-script` needed:
+
+- **Merge conflict markers**: `git grep -rl '^<<<<<<< ' --` — fails if any file contains conflict markers
+- **Case sensitivity conflicts**: `git ls-files | sort -f | awk 'BEGIN{prev=""} tolower($0)==tolower(prev){print prev; print $0} {prev=$0}'`
+- **Tracked files matching `.gitignore`**: `git ls-files -i --exclude-standard`
+- **Dotnet SDK version from global.json**: `jq -r '.sdk.version' src/global.json` — set `DOTNET_VERSION`; fall back to a default if absent
+
+Keep step names consistent with the original so PR history is legible.
+
+## Actions That Cannot Be Converted
+
+Do not replace these — specialised tooling required:
+
+- **Docker toolchain**: `docker/build-push-action`, `docker/login-action`, `docker/setup-buildx-action`, `docker/setup-qemu-action`
+- **AWS credential management**: `aws-actions/configure-aws-credentials`
+- **Git operations** (rebase, auto-commit): `stefanzweifel/git-auto-commit-action`, `bbeesley/gha-auto-dependabot-rebase`
+- **Security scanning**: `trufflesecurity/trufflehog`
+- **Multi-language linting**: `super-linter/super-linter`
+- **Complex config-driven label sync**: `crazy-max/ghaction-github-labeler`
+
+## Version Pinning
+
+Pin all `uses:` to a specific released version tag. Never use `@latest`, `@main`, `@master`, bare major tags (e.g. `@v6`), or branch refs.
+
+Correct: `uses: actions/github-script@v9.0.0`
+Wrong: `@latest`, `@v6`, branch refs
+
+## Keeping Actions Up to Date
+
+Whenever you add or modify a `uses:` reference, check all actions in that file are on the latest released version:
+
+1. For each `uses:`, run `gh api repos/<owner>/<action>/releases/latest --jq '.tag_name'`.
+2. If behind, update in the same commit.
+3. Never leave a file with a mix of updated and stale versions after touching it.
+
+## Bash Steps vs github-script
+
+**Default to `actions/github-script`** for any step doing more than a single command.
+
+Use `actions/github-script` for:
+
+- Any step calling the GitHub REST or GraphQL API
+- Any step processing git log output to make API decisions (e.g. creating branches, detecting missing releases)
+- Any step reading or writing files as part of a workflow (not a build tool)
+- Any step manipulating PR metadata (labels, assignees, draft state)
+- Any step with conditional logic — `if/else` in JavaScript is clearer than nested bash conditionals
+- Any step reading structured data (JSON, YAML) — use `JSON.parse` rather than `jq` pipelines
+
+Bash is acceptable only for steps meeting **all** of:
+
+- Single command or small sequence with no branching logic
+- No GitHub API calls
+- No structured data parsing
+- Intent immediately obvious without comments (e.g. `sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"`, `rm -fr "$HOME/.dotnet"`)
+
+Extract non-trivial bash logic appearing in more than one workflow or composite action (after checkout) into a local composite action at `.github/actions/<name>/action.yml`.
+
+## Step Field Ordering
+
+Use this consistent field order — omit fields not needed. `name:` is always first.
+
+### `run` steps
+
+> **`shell:` is mandatory on every `run:` step. A `run:` step without `shell:` is invalid.**
+
+```yaml
+      - name: "Step Name"
+        id: step-id           # only when output is referenced downstream
+        if: <condition>       # only when conditionally run
+        shell: bash
+        run: |
+          <commands>
+        env:
+          VARIABLE: "value"   # only when step-level env vars are needed
+```
+
+### `uses` steps
+
+```yaml
+      - name: "Step Name"
+        id: step-id           # only when output is referenced downstream
+        if: <condition>       # only when conditionally run
+        uses: owner/action@vX.Y.Z
+        env:
+          MY_VAR: ${{inputs.some-input}}  # pass user-controlled values via env to prevent injection
+        with:
+          setting: "value"
+```
+
+**Rules:**
+
+- `id:` follows `name:` — only when output is referenced downstream.
+- `if:` follows `id:` (or `name:` when no `id:`).
+- **`shell: bash` is mandatory on every `run:` step.**
+- `env:` and `with:` values are **maps** — never list syntax.
+- All string values must be double-quoted.
+- Indentation: 2 spaces per YAML level; steps under `steps:` indented 6 spaces, fields within a step 8 spaces.
+
+## Step Output Formatting
+
+> Applies to **GitHub Actions workflow steps only**. Standalone shell scripts use ANSI-coloured `✓`/`✗` — see [shell-scripts.instructions.md](shell-scripts.instructions.md#visual-indicators).
+
+| State | Character | Usage |
+| --- | --- | --- |
+| Pass / found / enabled | `✅` | Present, correct, or succeeded |
+| Fail / missing / disabled | `❌` | Absent, wrong, or failed |
+| Warning / skipped | `⚠️` | Skipped or needs attention |
+| Info / in-progress | `ℹ️` | Neutral informational output |
+
+See [github-workflows.examples.md](github-workflows.examples.md) for `core.info`/`core.setFailed` and bash `echo` usage examples.
+
+Use `echo "::error::..."` (bash) or `core.setFailed(...)` (github-script) only for conditions that must fail the step.
+
+### Surfacing key values without log diving
+
+Emit important values (version numbers, PR URLs, branch names) with **both** `core.info` and `core.notice`. `core.notice` creates a job annotation visible in the run summary — no log scrolling needed.
+
+See [github-workflows.examples.md](github-workflows.examples.md) for the `core.info` + `core.notice` pattern with ANSI colouring.
+
+> **ANSI escape sequences — use the literal string, never the raw byte.**
+> Write `\u001b` as six characters (`\`, `u`, `0`, `0`, `1`, `b`) inside JavaScript strings. Never insert the actual ESC byte (0x1B) into a YAML file — YAML forbids control characters and the workflow will be rejected.
+
+Use `core.notice` for values a human would want to see first: build version, deployment target, branch created. Not for internal diagnostics.
+
+## Dead Steps
+
+Remove a step only if **both** are true:
+
+1. Its output is never referenced by any subsequent step or job output.
+2. It has no meaningful side effect — does not configure the environment, install tools, run a check that can fail the job, or produce an artifact.
+
+Steps with side effects are never dead:
+
+- `aws-actions/configure-aws-credentials` — configures shell environment with credentials
+- `actions/setup-dotnet` / `actions/setup-node` — installs a runtime
+- `trufflesecurity/trufflehog` — fails the job if secrets are found
+- `super-linter/super-linter` — fails the job on lint errors
+- Any step writing to `$GITHUB_ENV` as its primary purpose
+
+## Checkout Configuration
+
+Use the minimum depth and tag fetching the job requires:
+
+- **Default**: `fetch-depth: 1` — sufficient for read, build, or scan
+- **Full history** (`fetch-depth: 0`): required only for `git diff --merge-base`, `git log`, `git rev-list`, or history traversal (changelog diffs, trufflehog, missing-release detection)
+- **`fetch-tags: true`**: required only when the job reads, creates, or compares tags
+- **`clean: true`**: include on self-hosted runners; may be omitted on GitHub-hosted
+
+## Permissions
+
+- Declare `permissions:` at workflow level (default: `contents: read`).
+- Override at job level as needed.
+- Never rely on default `GITHUB_TOKEN` write permissions without an explicit `permissions:` declaration.
+
+## Workflow Structure
+
+- Use `concurrency:` with `cancel-in-progress: true` on push-triggered feature-branch workflows.
+- Use `cancel-in-progress: false` on release or dependency-merge workflows.
+- Check required secrets with an explicit `run:` step before any dependent operation — fail fast with a clear error.
+
+## Collapsing Multi-Step Groups
+
+Before extracting into a composite action, consider collapsing into a **single `actions/github-script` step**. If the logic fits in 20–30 lines with no reuse value, collapsing is preferable.
+
+Collapse when:
+
+- Steps are conditional variants of the same operation
+- No external tool requirements — only API calls or env-var writes
+- Script body is readable without comments
+
+Extract to a composite action when:
+
+- Same sequence appears in two or more workflows or actions
+- Non-trivial inputs/outputs callers need to vary
+- Steps mix `actions/github-script` with other `uses:` steps
+
+## Composite Action Placement
+
+All local composite actions live under `.github/actions/<name>/action.yml`. Extract any step pattern that appears in more than one workflow or action — do not copy-paste.
+
+> **Any `uses:` step — local or remote — must only appear after `actions/checkout` has run.** Keep pre-checkout steps as inline `run:` bash steps (secret checks, workspace ownership fixes, env setup).
+
+### Infrastructure steps that repeat across every job
+
+Boilerplate setup blocks are high-value extraction targets. Examples:
+
+- Secret presence check → thin local action or inline `github-script` step failing with ❌ if empty
+- Workspace ownership fix (`sudo chown`) and active env var setup → keep as inline `run:` bash steps
+
+When extracting pure-infrastructure steps, the action may have no `outputs:` and only optional inputs for minor variants.
+
+### Unifying invocations that differ only in value source
+
+When the same action is called in multiple places with identical parameters except one value sourced differently, extract into a local action requiring that value as an explicit input. See [github-workflows.examples.md](github-workflows.examples.md) for the caller pattern.
+
+## Composite Action Inputs vs Environment Variables
+
+Composite actions must never silently depend on caller-set env vars — invisible contracts cause obscure failures.
+
+### Prefer explicit inputs
+
+Declare every required value as a named input with `required: true`. See [github-workflows.examples.md](github-workflows.examples.md) for a full action.yml + caller example.
+
+### When env vars cannot be avoided
+
+Add a validation step as the **first step**, checking each required env var and failing immediately with a clear ❌ naming the missing variable. See [github-workflows.examples.md](github-workflows.examples.md) for the template.
+
+**Rules:**
+
+- Prefer `inputs:` over env var dependencies — explicit over implicit.
+- Never read an env var without declaring it as an input or validating its presence first.
+- Validation must be the first step.
+- Error messages must name every missing variable.

--- a/ai/global/gitignore.instructions.md
+++ b/ai/global/gitignore.instructions.md
@@ -1,0 +1,25 @@
+# .gitignore Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## IDE Files
+
+Never commit IDE-specific files or folders, including:
+
+- `.idea/` — JetBrains IDEs
+- `.vscode/` — Visual Studio Code
+- `.vs/` — Visual Studio
+
+These are covered by the root `.gitignore` in `credfeto/cs-template`; if any are missing, update there.
+
+## Root `.gitignore`
+
+The root `.gitignore` is the global baseline — only edit it in `credfeto/cs-template`. Updates are distributed to derived repositories via the standard template update mechanism.
+
+## Additional `.gitignore` Files
+
+Derived repositories may add `.gitignore` files for repo-specific concerns (language build output, generated content, local tooling artefacts), placed at the appropriate directory level.
+
+## Consistency
+
+When creating or modifying any `.gitignore`, check it against the root to ensure no duplication or conflicts.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -1,0 +1,57 @@
+# Global instructions
+
+This is an index of global instructions that apply to all projects.
+
+- Ensure consistency across all projects.
+- This folder should be maintained ONLY in the `git@github.com:credfeto/cs-template.git` repository.
+- Updates to this folder will be distributed using an external mechanism.
+- Rule files are named `<category>.instructions.md`; code reference files are named `<category>.examples.md`.
+- All files must maintain a backlink to this index.
+- When adding a rule, check all other files for conflicts or duplication.
+
+## Always Load
+
+Read all of these before starting any task, regardless of language or context.
+
+| File | Covers |
+| --- | --- |
+| [git.instructions.md](git.instructions.md) | Prerequisites, build/test verification, git identity/GPG, branching, commits, GitHub issues |
+| [task-workflow.instructions.md](task-workflow.instructions.md) | Agent routing table, model selection, failure handling, issue/PR assignment, commit cadence, resuming work |
+| [code-quality.instructions.md](code-quality.instructions.md) | Code coverage, tests, async, immutability, parameterised tests, refactoring |
+| [documentation.instructions.md](documentation.instructions.md) | README, CHANGELOG conventions |
+| [security.instructions.md](security.instructions.md) | No secrets in code, input validation, output sanitisation |
+| [error-handling.instructions.md](error-handling.instructions.md) | Explicit error handling, propagation, safe surfacing |
+| [logging.instructions.md](logging.instructions.md) | Structured logging, log levels, no PII/secrets |
+| [packages.instructions.md](packages.instructions.md) | Secure versions, managed vs native, deprecated packages |
+
+## Load When Applicable
+
+Load these only when the work involves the relevant technology or context.
+
+| File | Load When | Covers |
+| --- | --- | --- |
+| [dotnet.instructions.md](dotnet.instructions.md) | Any `.csproj`, `.sln`, or `.slnx` file is present | Build/test, solution structure, test patterns, ValueTask, CancellationToken, NuGet audit |
+| [sql.instructions.md](sql.instructions.md) | Any `.sql` file or SQL project is present | SQL linting, local DB connection, performance optimisation |
+| [shell-scripts.instructions.md](shell-scripts.instructions.md) | Any `.sh` file is present or shell script work is needed | Shebang, linting, output helper conventions (`die`/`success`/`info`) |
+| [shell.firewall.instructions.md](shell.firewall.instructions.md) | Firewall rule management is needed | `firewall-cmd` rules, private network constants |
+| [github-workflows.instructions.md](github-workflows.instructions.md) | Any `.github/workflows/*.yml` file is present or being created | Action policy, composite actions, step ordering, permissions, version pinning |
+| [api.instructions.md](api.instructions.md) | An HTTP API is being created or modified | `.http` test file requirements |
+| [performance.instructions.md](performance.instructions.md) | Performance-critical code is being written or optimised | Design principles, benchmarks, optimisation workflow |
+| [agent-roles.instructions.md](agent-roles.instructions.md) | You are acting as a named agent (Orchestrator, Code Writer, Code Tester, etc.) | Detailed per-agent responsibilities and behaviour |
+| [changelog.instructions.md](changelog.instructions.md) | You need to add or update a changelog entry, or you are the Changelog agent | Format, tooling (`dotnet changelog`), when to add entries, add/remove commands |
+| [git-commits.instructions.md](git-commits.instructions.md) | You are about to commit, or you are the Committer agent | Commit size rules, empty commit check, push cadence, Conventional Commits format |
+| [gitignore.instructions.md](gitignore.instructions.md) | Any `.gitignore` file is being created or modified | IDE file exclusions, root `.gitignore` ownership, consistency checks |
+| [language.instructions.md](language.instructions.md) | Writing code, documentation, comments, or commit messages | UK English for docs/comments; platform convention for identifiers |
+
+## Reference Files (Load on Demand)
+
+These contain code examples only. Load them when actively writing or modifying the scripts they describe — not as part of routine rule-loading.
+
+| File | Load When |
+| --- | --- |
+| [shell-scripts.examples.md](shell-scripts.examples.md) | Writing or modifying shell scripts — provides `die`, `success`, `info`, `is_ai_agent` implementations |
+| [shell.firewall.examples.md](shell.firewall.examples.md) | Writing firewall scripts — provides `allow_ipv4`, `allow_ipv6`, `open_port_for_private_networks` implementations |
+| [github-workflows.examples.md](github-workflows.examples.md) | Creating or scaffolding a local composite action — provides action template, explicit inputs, env-var validation step |
+| [sql.examples.md](sql.examples.md) | Writing SQL or database connection scripts — provides `.database` file format, `sqlcmd` invocation, and `SET STATISTICS` baseline template |
+| [dotnet.examples.md](dotnet.examples.md) | Writing .NET DI setup tests — provides `AddMockedService` and `IOptions` patterns |
+| [git.examples.md](git.examples.md) | Implementing or debugging git identity checks — provides GPG validation script and template escalation command |

--- a/ai/global/language.instructions.md
+++ b/ai/global/language.instructions.md
@@ -1,0 +1,14 @@
+# Language Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## English Variant
+
+- All documentation, comments, and commit messages must be written in **UK English**.
+- This includes prose in `README.md`, `CHANGELOG.md`, inline code comments, and AI instruction files.
+
+## Code Identifiers
+
+- Variable names, function names, class names, and other code identifiers should follow the **platform or library convention**, which is typically US English — do not force UK spellings onto them.
+- For example: use `Color` not `Colour` when the platform or library defines it as `Color`; mixing conventions produces confusing and inconsistent code (e.g. `Color colour = Color.Red` is actively harmful).
+- Where a library or platform uses a non-English language for its identifiers, use **English** for any variables or identifiers that interact with it.

--- a/ai/global/logging.instructions.md
+++ b/ai/global/logging.instructions.md
@@ -1,0 +1,24 @@
+# Logging Instructions
+
+> Load when: writing code that produces log output.
+
+[Back to Global Instructions Index](index.md)
+
+## Rules
+
+- Use structured logging — key-value pairs or structured objects, never concatenated strings.
+- Log at service/system boundaries (requests, outgoing calls, significant state transitions).
+- Log enough context to diagnose a problem without reproducing it — include relevant identifiers and state.
+- Never log PII (names, emails, phone numbers, IP addresses, or anything that identifies an individual).
+- Never log secrets, credentials, tokens, or passwords — see [security.instructions.md](security.instructions.md#secrets-and-credentials).
+- Avoid logging large payloads in full — summarise or truncate.
+
+## Log Levels
+
+| Level | Use when |
+| --- | --- |
+| Error | Unexpected failure; operation could not complete |
+| Warning | Unexpected but recoverable; may need investigation |
+| Information | Significant business/operational events (service started, job completed) |
+| Debug | Detailed diagnostics for development; disabled in production by default |
+| Trace | Very fine-grained; never in production |

--- a/ai/global/packages.instructions.md
+++ b/ai/global/packages.instructions.md
@@ -1,0 +1,11 @@
+# Package Management Instructions
+
+> Load when: adding, updating, or reviewing package/library dependencies.
+
+[Back to Global Instructions Index](index.md)
+
+- Use only secure package versions — see [security.instructions.md](security.instructions.md#dependency-vulnerability-scanning).
+- In managed languages (.NET, JVM, Python), prefer managed libraries over native; only use native if it is the most actively maintained and stable option.
+- Avoid deprecated or obsolete packages and language features; if unavoidable, add a comment explaining why and when it can be removed.
+- Prefer the standard library; where insufficient, use well-known actively-maintained third-party libraries.
+- If you find hand-rolled code duplicating standard-library or trusted-third-party functionality, raise a GitHub issue — do not modify it inline.

--- a/ai/global/performance.instructions.md
+++ b/ai/global/performance.instructions.md
@@ -1,0 +1,26 @@
+# Performance Instructions
+
+> Load when: writing or optimising performance-critical code.
+
+[Back to Global Instructions Index](index.md)
+
+## Design and Code
+
+- Optimise for speed first, then memory (allocations).
+- Prefer algorithms and data structures with better time and space complexity.
+- Avoid unnecessary allocations — reuse instances, use pooling for frequently allocated objects.
+- Avoid copying data unnecessarily — work in-place or pass by reference where safe.
+- Avoid blocking calls on hot paths — prefer async.
+- Avoid high-level abstractions (functional pipelines, heavy reflection, dynamic dispatch) on hot paths; prefer lower-level constructs.
+- Use low-allocation APIs when processing strings or buffers.
+- Cache expensive computed values that do not change within a given scope.
+- Be mindful of implicit conversions, boxing, or type coercions on hot paths.
+
+## Benchmarks and Optimisation
+
+- Write benchmarks for performance-critical code; commit them alongside the code they measure.
+- In .NET repositories, write benchmarks as xUnit tests in the benchmark test project, using `FunFair.Test.Common` helpers such as `Benchmark<BenchmarkClass>()` to run the benchmark and `SummaryExtensions.AssertAllocationsAtMost(...)` to assert the measured thresholds.
+- Record a baseline — regressions against it are not acceptable.
+- Assert memory allocation limits using `FunFair.Test.Common` extensions (zero or explicit byte threshold); do not roll custom helpers.
+- Ensure tests and benchmarks pass before optimising; commit them first as a standalone commit.
+- Only commit an optimisation if it produces a measurable gain against the baseline; otherwise discard it but keep the tests and benchmarks.

--- a/ai/global/security.instructions.md
+++ b/ai/global/security.instructions.md
@@ -1,0 +1,31 @@
+# Security Instructions
+
+> Always loaded.
+
+[Back to Global Instructions Index](index.md)
+
+## Secrets and Credentials
+
+- Never commit secrets, credentials, API keys, tokens, or passwords.
+- If accidentally committed, treat it as compromised immediately — rotate and purge from history.
+- Use environment variables, secrets managers, or platform vaults for all runtime secrets.
+- Refer to local AI instructions for the project-specific secrets management approach.
+
+## Input Validation
+
+- Validate all external input (user input, API requests, file contents, env vars, message queues) at the entry boundary before use.
+- Reject input that does not conform to the expected shape, type, range, or format — never silently fix or guess malformed input.
+
+## Output Sanitisation
+
+- Sanitise all output containing external data for its context (HTML encoding, parameterised queries, shell escaping).
+- Never construct queries, commands, or markup by string-concatenating untrusted input.
+
+## Threat Modelling
+
+- For any new feature handling data, exposing an endpoint, or introducing a trust boundary: model threats before writing code (who can call it, what can they send, what can go wrong). Document significant threats and mitigations.
+
+## Dependency Vulnerability Scanning
+
+- Scan dependencies for known vulnerabilities in CI; assess and resolve promptly.
+- Refer to local AI instructions for the project-specific scanning tool.

--- a/ai/global/shell-scripts.examples.md
+++ b/ai/global/shell-scripts.examples.md
@@ -1,0 +1,55 @@
+# Shell Script Examples
+
+[Back to Global Instructions Index](index.md)
+
+Reference implementations for the helper functions described in [shell-scripts.instructions.md](shell-scripts.instructions.md). Load this file when actively writing or modifying shell scripts.
+
+## Output Helpers
+
+```sh
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+```
+
+Always direct `die()` to stderr (`>&2`) so error messages are not captured by stdout pipelines. Use `"$*"` to pass the message as a single string (required for `shellcheck` and `checkbashisms` compliance).
+
+### Usage Example
+
+```sh
+info "Opening port ${PORT}/tcp..."   # correct — uses helper
+printf '→ Opening port %s/tcp...\n' "${PORT}"  # wrong — naked printf
+```
+
+## AI Agent Detection
+
+```sh
+# Returns true (0) when running inside a Claude Code Bash-tool session.
+# Claude Code sets CLAUDECODE=1 in every shell it spawns via the Bash tool;
+# that value is inherited by subprocesses (e.g. git hooks).
+# Source: https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables
+is_ai_agent() {
+    [ "${CLAUDECODE}" = "1" ]
+}
+```
+
+Usage:
+
+```sh
+if is_ai_agent; then
+    die "Prohibited — did you read the .ai-instructions?"
+else
+    die "Normal human-facing error message"
+fi
+```
+
+Define `is_ai_agent` alongside the other output helpers near the top of the script, not inline at the point of use. Always keep the source URL comment.

--- a/ai/global/shell-scripts.instructions.md
+++ b/ai/global/shell-scripts.instructions.md
@@ -1,0 +1,24 @@
+# Shell Script Instructions
+
+> Load when: any `.sh` file is present or shell script work is needed.
+
+[Back to Global Instructions Index](index.md)
+
+## Shebang
+
+- Prefer `#!/bin/sh`; only use `#!/bin/bash` if bash-specific functionality is genuinely required.
+- All `#!/bin/sh` scripts must pass `shellcheck` and `checkbashisms` before committing.
+
+## Output Helpers
+
+> Applies to **standalone shell scripts only**. GitHub Actions `run:` steps use emoji indicators — see [github-workflows.instructions.md](github-workflows.instructions.md#step-output-formatting).
+
+Use `die`, `success`, and `info` for all user-facing output — never bare `echo` or `printf`. See [shell-scripts.examples.md](shell-scripts.examples.md) for implementations and usage examples.
+
+- `die` — fatal error, red `✗` to stderr, exits non-zero
+- `success` — completion, green `✓`
+- `info` — progress/step announcement, green `→`
+
+## AI Agent Detection
+
+Scripts that behave differently when invoked by an AI agent must use the standard `is_ai_agent` helper — see [shell-scripts.examples.md](shell-scripts.examples.md).

--- a/ai/global/shell.firewall.examples.md
+++ b/ai/global/shell.firewall.examples.md
@@ -1,0 +1,74 @@
+# Firewall Script Examples
+
+[Back to Global Instructions Index](index.md)
+
+Reference implementations for the firewall helpers described in [shell.firewall.instructions.md](shell.firewall.instructions.md). Load this file when actively writing or modifying firewall scripts.
+
+## Private Network Constants
+
+Define these at the top of any script that manages firewall rules:
+
+```bash
+IPV4_PRIVATE_RANGES=(
+    "10.0.0.0/8"
+    "172.16.0.0/12"
+    "192.168.0.0/16"
+)
+
+IPV6_PRIVATE_RANGES=(
+    "fc00::/7"
+    "fe80::/10"
+)
+```
+
+## Helper Functions
+
+```bash
+allow_ipv4() {
+    local subnet="$1"
+    local port="$2"
+    local protocol="$3"
+    firewall-cmd --permanent \
+        --add-rich-rule="rule family='ipv4' source address='${subnet}' port port='${port}' protocol='${protocol}' accept"
+}
+
+allow_ipv6() {
+    local subnet="$1"
+    local port="$2"
+    local protocol="$3"
+    firewall-cmd --permanent \
+        --add-rich-rule="rule family='ipv6' source address='${subnet}' port port='${port}' protocol='${protocol}' accept"
+}
+
+open_port_for_private_networks() {
+    local port="$1"
+    local protocol="${2:-tcp}"
+
+    for subnet in "${IPV4_PRIVATE_RANGES[@]}"; do
+        allow_ipv4 "${subnet}" "${port}" "${protocol}"
+    done
+
+    for subnet in "${IPV6_PRIVATE_RANGES[@]}"; do
+        allow_ipv6 "${subnet}" "${port}" "${protocol}"
+    done
+
+    firewall-cmd --reload
+}
+```
+
+## Usage
+
+To allow a port from all private networks (both IPv4 and IPv6):
+
+```bash
+open_port_for_private_networks 8080 tcp
+open_port_for_private_networks 53 udp
+```
+
+To allow a single specific subnet:
+
+```bash
+allow_ipv4 "192.168.0.0/16" 1234 tcp
+allow_ipv6 "fc00::/7" 1234 tcp
+firewall-cmd --reload
+```

--- a/ai/global/shell.firewall.instructions.md
+++ b/ai/global/shell.firewall.instructions.md
@@ -1,0 +1,14 @@
+# Shell Firewall Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## Firewall Rules (`firewall-cmd`)
+
+Use three standard helpers for all firewall rule management. See [shell.firewall.examples.md](shell.firewall.examples.md) for implementations of `allow_ipv4`, `allow_ipv6`, and `open_port_for_private_networks`, including the `IPV4_PRIVATE_RANGES` and `IPV6_PRIVATE_RANGES` constants.
+
+### Rules
+
+- Always use `--permanent` so rules survive reboots.
+- Always call `firewall-cmd --reload` after adding rules — call it once after all rules for a given operation are added, not once per rule.
+- Never open ports to `0.0.0.0/0` or `::/0` without an explicit security review.
+- Use `open_port_for_private_networks` as the default when a service should be reachable from LAN/VPN; only open to the internet if the service is intentionally public-facing.

--- a/ai/global/sql.examples.md
+++ b/ai/global/sql.examples.md
@@ -1,0 +1,39 @@
+# SQL Examples
+
+[Back to Global Instructions Index](index.md)
+
+Reference examples for [sql.instructions.md](sql.instructions.md). Load when writing or debugging SQL, database connection scripts, or stored procedures.
+
+## Local Database Connection
+
+`$HOME/.database` (machine-specific, never committed):
+
+```dotenv
+SERVER=localhost
+USER=sa
+PASSWORD=<password>
+```
+
+`<repo>/.database` (committed, repo-specific):
+
+```dotenv
+DB=Treasury
+```
+
+Ad-hoc `sqlcmd` invocation (only needed outside `<repo>/testdb`):
+
+```sh
+. "$HOME/.database" && . .database && sqlcmd -S "$SERVER" -U "$USER" -P "$PASSWORD" -d "$DB" ...
+```
+
+## Performance Baseline
+
+Run before and after optimising a stored procedure or view:
+
+```sql
+SET STATISTICS IO ON;
+SET STATISTICS TIME ON;
+-- run the example EXEC call
+SET STATISTICS IO OFF;
+SET STATISTICS TIME OFF;
+```

--- a/ai/global/sql.instructions.md
+++ b/ai/global/sql.instructions.md
@@ -1,0 +1,35 @@
+# SQL Instructions
+
+> Load when: any `.sql` file or SQL project is present.
+
+[Back to Global Instructions Index](index.md)
+
+## Linting
+
+Run a SQL linter appropriate for the dialect before every commit. Refer to local AI instructions for the specific linter and command.
+
+## Local Database Connection (MS SQL Server)
+
+Two `.database` files provide the local connection — see [sql.examples.md](sql.examples.md) for their contents and the ad-hoc `sqlcmd` invocation.
+
+- **`$HOME/.database`** — machine-specific credentials, never committed.
+- **`<repo>/.database`** — committed, repo-specific (database name).
+
+The `<repo>/testdb` script sources both automatically — do NOT pre-source them before calling `<repo>/testdb`.
+
+## Performance Optimisation
+
+Before committing a stored procedure or view, reduce IO and CPU:
+
+1. **Baseline** — run the example EXEC with `SET STATISTICS IO/TIME ON` — see [sql.examples.md](sql.examples.md).
+2. **Identify hotspots** — high logical reads on large tables; prefer index seeks over table scans.
+3. **Optimise** (minimum set):
+   - Add `WITH (NOLOCK)` to every table/view reference in read-only SPs and views.
+   - Push `WHERE` predicates into subqueries/CTEs to seek before joining.
+   - Use covering indexes where available.
+   - Prefer table variables with a primary key (small sets) or `#temp` tables with statistics (large sets) over repeated scans.
+   - Avoid scalar UDFs in `WHERE`/`JOIN` clauses — they suppress parallelism.
+4. **No query hints** — avoid `OPTION (...)`, `FORCE ORDER`, `USE PLAN`, or index hints unless measured proof justifies them.
+5. **Linter constraint (SRP0009)** — build rules block `DATEPART()` / function calls on columns in `WHERE` clauses; use `DECLARE` variables to pre-compute values outside the query.
+6. **Record** — update `docs/Benchmarks/<Schema>.md` with before/after logical-read and Workfile totals for material changes, including example parameters.
+7. **Known Bottlenecks** — if a performance issue cannot be fixed immediately, document it as a "Known Bottleneck" in `docs/Benchmarks/<Schema>.md` and raise a GitHub issue with the bottleneck details, affected procedure/view, observed stats, and proposed fix. Reference the issue number in the benchmark file.

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -1,0 +1,121 @@
+# Task Workflow Instructions
+
+> Always loaded.
+
+[Back to Global Instructions Index](index.md)
+
+## Assignment
+
+- Assign yourself to the issue before starting: `gh issue edit <number> --add-assignee @me`.
+- Only work on unassigned issues or issues already assigned to you.
+- Assign yourself to PRs when creating or updating: `gh pr edit <number> --add-assignee @me`.
+
+## PR Lifecycle
+
+- Only one active branch or open PR per repository at a time; do not create another until the current one is merged and closed.
+- When adding work to an open PR (review comments, missing coverage, CI fixes), convert to draft first: `gh pr ready <number> --undo`. Keep it in draft until Code Tester and Code Reviewer are both satisfied — only PR Submitter converts it back.
+
+## Bot-Created PRs (MANDATORY — treat as your own)
+
+github is configured to automatically create PRs from pushed branches. These PRs appear authored by `app/github-actions` but the commits are authored by you. **They are your work — treat them identically to PRs you created yourself.**
+
+**Before starting any work in a repository:**
+
+1. Run `gh pr list --state open --repo <owner/repo> --json number,title,author,headRefName,url` — no `--author @me` filter.
+2. For any PR authored by `app/github-actions`, check the commit authors: `gh pr view <n> --repo <owner/repo> --json commits --jq '.commits[].authors[].login'`.
+3. If **all commits** are from your account (you are the sole committer), **take ownership**: update the PR title and body to match the proper format (summary, `Closes #<n>`, test plan), add yourself as assignee, and treat it as your active PR for that repo.
+4. If commits are from multiple authors (e.g. you plus a human or Copilot), do **not** take over — leave the PR as-is and do not claim it as yours.
+5. Do **not** create a new branch or PR for the same issue — that would be duplicate work.
+
+**When you find a duplicate pair** (a bot-created PR and one you authored yourself, for the same issue or branch):
+
+- Keep whichever has the more complete body and later review activity.
+- Close the other with a comment explaining which PR supersedes it.
+
+**Checking for existing work before branching (MANDATORY):**
+
+- Check branch names in all open PRs, not just PR authors. If any open PR's `headRefName` contains the issue number, that is your work from a prior session — resume it instead of creating a new branch.
+
+## PR Title, Body, and Label Sync (MANDATORY)
+
+When creating or updating a PR linked to one or more issues:
+
+1. Ensure the **title** accurately reflects all changes in the PR — update it if the scope has changed.
+2. Ensure the **body** summarises all changes and includes `Closes #<n>` for each linked issue.
+3. Copy all issue labels: `gh issue view <n> --json labels --jq '.labels[].name'` → `gh pr edit <n> --add-label "<label>"`
+
+Repeat after every push or PR update.
+
+## Rules Compliance for In-Flight Work
+
+Whenever an instruction file is added or updated, re-evaluate all open branches and PRs against the new rules. Fix any non-compliance before continuing — treat it the same as a CI failure.
+
+## Instruction File Source Routing
+
+- If the file originates from `funfair/funfair-server-template` or `credfeto/cs-template`, raise an issue there first.
+- Otherwise, make the change directly in the current repository.
+
+## Large Multi-Handler / Multi-App Tasks
+
+1. Create a top-level GitHub issue (if none specified); assign it; include the full original prompt as the body.
+2. Comment findings on the issue before starting (handlers found, current state, etc.).
+3. For each handler/app/component, create a sub-issue referencing the top-level issue; use the sub-issue number in branch names and commit messages.
+4. Work on one handler/component at a time — commit and push before starting the next.
+5. Close the sub-issue as soon as the relevant commits are pushed.
+
+## Issue Tracking
+
+- Only update issues if `gh` is installed and authenticated (`gh auth status`); otherwise read code and git log for state.
+- Each sub-issue must list files with status: `❌ Not started` / `🔄 In progress` / `✅ Done` — update after each commit+push.
+- The top-level issue tracks only handler/app-level status (sub-issues open/closed, branches merged).
+- Update the sub-issue after each significant commit+push; update the top-level issue when overall status changes.
+- When resuming, update the issue with current state before continuing.
+
+## Commit, Push, and Issue Update Cadence
+
+- One logical change per commit; do not batch unrelated changes.
+
+Per-file cadence for coverage tasks:
+
+1. Write tests until the file reaches target coverage.
+2. Commit the test file; push immediately.
+3. Update the sub-issue to mark the file done.
+4. Move to the next file.
+
+For complex files, commit+push+update after each round — do not wait until fully complete.
+
+> Pre-commit hooks may make commits slow — wait for them to complete before assuming failure.
+
+## Multi-Agent Implementation and Review Pattern
+
+### Model Selection
+
+| Use full model | Use lesser model |
+| --- | --- |
+| Orchestrator, Code Writer, Code Reviewer, Code Fixer, CI Debugger, Dependency Updater | Code Tester, Committer, Changelog, Rebase Agent, PR Submitter, CI Monitor |
+
+### Failure Handling — No Self-Repair
+
+Mechanical agents must not interpret or fix failures. When a check fails: capture the full output, stop immediately, and return failure details verbatim to the calling agent.
+
+### Routing Rules
+
+Standard loop pattern: Code Writer/Fixer loops ≤5 with Code Tester; Code Reviewer loops ≤5 re-running both each round.
+
+| Work type | Agent sequence |
+| --- | --- |
+| New feature / bug fix / refactor | Code Writer → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
+| `CHANGES_REQUESTED` on existing PR, or verbal/chat request for changes on an open PR | Code Fixer (respond to every comment) → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
+| Coverage-only task | Code Writer (tests only) → Code Tester → Code Reviewer → Changelog → Committer → PR Submitter → CI Monitor |
+| Documentation-only | Code Writer (docs only) → PR Submitter |
+| Rebase requested | Rebase Agent → PR Submitter |
+| CI failure (unknown cause) | CI Debugger |
+| Dependabot / dependency update | Dependency Updater |
+
+For detailed agent role definitions, see [agent-roles.instructions.md](agent-roles.instructions.md).
+
+## Resuming Interrupted Work
+
+- Check the status of existing issues and branches; skip merged branches.
+- For unmerged branches, decide whether to continue or delete and recreate.
+- Update the top-level issue with current status and next steps before resuming.

--- a/cache/install-dotnet
+++ b/cache/install-dotnet
@@ -14,45 +14,58 @@ export PROXY_HOST=https://builds.dotnet.local:5555
 
 USER_AGENT="DotnetVersionChecker/1.0.0"
 
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
+say() {
+    info "dotnet-install: $1"
+}
+
+say_verbose() {
+    if [ "$verbose" = true ]; then
+        info "$1"
+    fi
+}
+
+say_err() {
+    die "$1"
+}
+
 # args:
 # zip_path - $1
 # out_path - $2
 extract_dotnet_package() {
-#    eval $invocation
-
     local zip_path="$1"
     local out_path="$2"
+    local temp_out_path
+    temp_out_path="$(mktemp -d "$temporary_file_template")"
 
-    local temp_out_path="$(mktemp -d "$temporary_file_template")"
-
-    #echo "Zip: $zip_path"
-    #echo "Out: $out_path"
-    #echo "Temp: $temp_out_path"
-
-    echo "Extracting..."
+    info "Extracting..."
     local failed=false
     tar -xvzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true
 
     if [ "$failed" = true ]; then
       doas rm -f "$zip_path" && say_verbose "Temporary archive file $zip_path was removed"
       say_err "Extraction failed"
-      return 1
     fi
 
-    echo "Install..."
+    info "Install..."
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
     find "$temp_out_path" -type f | grep -Eo "$folders_with_version_regex" | sort | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" false
     find "$temp_out_path" -type f | grep -Ev "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" "$override_non_versioned_files"
 
     doas rm -rf "$temp_out_path"
-    #doas rm -f "$zip_path" && say_verbose "Temporary archive file $zip_path was removed"
 
-    [ -f "$out_path/dotnet" ] || echo "Missing dotnet"
     [ -f "$out_path/dotnet" ] || failed=true
 
     if [ "$failed" = true ]; then
         say_err "Extraction failed"
-        return 1
     fi
     return 0
 }
@@ -63,22 +76,25 @@ extract_dotnet_package() {
 # out_path - $2
 # override - $3
 copy_files_or_dirs_from_list() {
-    eval $invocation
-
-    local root_path="$(remove_trailing_slash "$1")"
-    local out_path="$(remove_trailing_slash "$2")"
+    local root_path
+    local out_path
+    local override_switch
+    root_path="$(remove_trailing_slash "$1")"
+    out_path="$(remove_trailing_slash "$2")"
     local override="$3"
-    local override_switch="$(get_cp_options "$override")"
+    override_switch="$(get_cp_options "$override")"
 
     cat | uniq | while read -r file_path; do
-        local path="$(remove_beginning_slash "${file_path#$root_path}")"
-        local target="$out_path/$path"
-        if [ "$override" = true ] || (! ([ -d "$target" ] || [ -e "$target" ])); then
+        local path
+        local target
+        path="$(remove_beginning_slash "${file_path#"$root_path"}")"
+        target="$out_path/$path"
+        if [ "$override" = true ] || ! { [ -d "$target" ] || [ -e "$target" ]; }; then
             doas mkdir -p "$out_path/$(dirname "$path")"
             if [ -d "$target" ]; then
                 doas rm -rf "$target"
             fi
-            doas cp -R $override_switch "$root_path/$path" "$target"
+            doas cp -R "$override_switch" "$root_path/$path" "$target"
         fi
     done
 }
@@ -86,8 +102,6 @@ copy_files_or_dirs_from_list() {
 # args:
 # override - $1 (boolean, true or false)
 get_cp_options() {
-    eval $invocation
-
     local override="$1"
     local override_switch=""
 
@@ -95,9 +109,10 @@ get_cp_options() {
         override_switch="-n"
 
         # create temporary files to check if 'cp -u' is supported
+        local tmp_dir
         tmp_dir="$(doas mktemp -d)"
-        tmp_file="$tmp_dir/testfile"
-        tmp_file2="$tmp_dir/testfile2"
+        local tmp_file="$tmp_dir/testfile"
+        local tmp_file2="$tmp_dir/testfile2"
 
         doas touch "$tmp_file"
 
@@ -114,40 +129,18 @@ get_cp_options() {
     echo "$override_switch"
 }
 
-
 # args:
 # input - $1
 remove_trailing_slash() {
-    #eval $invocation
-
     local input="${1:-}"
     echo "${input%/}"
-    return 0
 }
 
 # args:
 # input - $1
 remove_beginning_slash() {
-    #eval $invocation
-
     local input="${1:-}"
     echo "${input#/}"
-    return 0
-}
-
-say() {
-    echo "dotnet-install: $1"
-}
-
-say_verbose() {
-    if [ "$verbose" = true ]; then
-        say "$1"
-    fi
-}
-
-say_err() {
-  say "$1"
-  exit 1
 }
 
 # args:
@@ -157,37 +150,32 @@ install_dotnet_version() {
   local VERSION="$1"
   local SDK_VERSION="$2"
 
-  echo "**********************************************************************************************"
-  echo "* Installing dotnet: $VERSION"
-  echo "*       Current SDK: $SDK_VERSION"
-  echo "**********************************************************************************************"
-  echo ""
+  info "**********************************************************************************************"
+  info "* Installing dotnet: $VERSION"
+  info "*       Current SDK: $SDK_VERSION"
+  info "**********************************************************************************************"
 
   if [ -f "$DOTNET_ROOT/dotnet" ]; then
-#    echo "Currently installed:"
-#    "$DOTNET_ROOT/dotnet" --list-sdks | cut -f 1 -d " "
-#    echo "Check $SDK_VERSION installed:"
-#    "$DOTNET_ROOT/dotnet" --list-sdks | cut -f 1 -d " " | grep -F "$SDK_VERSION"
+    local SDK_INSTALLED
     SDK_INSTALLED=$("$DOTNET_ROOT/dotnet" --list-sdks | cut -f 1 -d " " | grep -F "$SDK_VERSION")
-    #echo "Check Installed: $SDK_INSTALLED"
 
     if [ "$SDK_INSTALLED" = "$SDK_VERSION" ]; then
-      echo "Already installed - skipping"
+      info "Already installed - skipping"
       return
     else
-      echo "New Install (Previous installed): $SDK_VERSION"
+      info "New Install (Previous installed): $SDK_VERSION"
     fi
   else
-    echo "New Install (None installed): $SDK_VERSION"
+    info "New Install (None installed): $SDK_VERSION"
   fi
 
-  TEMPORARY_FILE="$DOWNLOADS/$SDK_VERSION.tgz"
+  local TEMPORARY_FILE="$DOWNLOADS/$SDK_VERSION.tgz"
 
   if [ -f "$TEMPORARY_FILE" ]; then
-    echo "Already downloaded $TEMPORARY_FILE"
+    info "Already downloaded $TEMPORARY_FILE"
   else
-    DOWNLOAD_URL=$PROXY_HOST/dotnet/Sdk/$SDK_VERSION/dotnet-sdk-$SDK_VERSION-linux-musl-x64.tar.gz
-    echo "Download $DOWNLOAD_URL to $TEMPORARY_FILE..."
+    local DOWNLOAD_URL="$PROXY_HOST/dotnet/Sdk/$SDK_VERSION/dotnet-sdk-$SDK_VERSION-linux-musl-x64.tar.gz"
+    info "Download $DOWNLOAD_URL to $TEMPORARY_FILE..."
     curl \
           --max-time 120 \
           --retry 5 \
@@ -209,7 +197,7 @@ install_dotnet_version() {
 }
 
 get_latest_dotnet_sdk_version() {
-    DOTNET_CHANNEL_VERSION=$1
+    local DOTNET_CHANNEL_VERSION="$1"
     [ -z "$DOTNET_CHANNEL_VERSION" ] && die "Dotnet channel version not defined"
     curl \
        --max-time 120 \

--- a/cache/populate
+++ b/cache/populate
@@ -5,9 +5,16 @@ VERSIONS_TO_INSTALL="8.0 9.0 10.0"
 BASEDIR="$(dirname "$(readlink -f "$0")")"
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 
@@ -37,6 +44,7 @@ export MSBUILDTERMINALLOGGER="auto"
 [ -f "/bin/bash" ] || die "bash not found"
 [ -f "/bin/tar" ] || die "tar not found"
 
+# shellcheck source=/dev/null
 . "$BASEDIR/install-dotnet"
 
 TOOLS="sleet \
@@ -59,31 +67,28 @@ installDotNet() {
 
     [ -z "$SDK_VERSION" ] && die "Could not determine latest SDK version for $VERSION"
 
-    echo "**********************************************************************************************"
-    echo "* Installing dotnet: $VERSION"
-    echo "*       Current SDK: $SDK_VERSION"
-    echo "**********************************************************************************************"
-    echo ""
+    info "**********************************************************************************************"
+    info "* Installing dotnet: $VERSION"
+    info "*       Current SDK: $SDK_VERSION"
+    info "**********************************************************************************************"
 
     install_dotnet_version "$VERSION" "$SDK_VERSION"
 
    done
-  echo ""
-  echo "**********************************************************************************************"
-  echo "* Dotnet Installed"
-  echo "**********************************************************************************************"
-  echo ""
-  echo ""
+  info ""
+  info "**********************************************************************************************"
+  info "* Dotnet Installed"
+  info "**********************************************************************************************"
 }
 
 update() {
 
-    echo "Updating packages:"
+    info "Updating packages:"
     for PACKAGE in ${TOOLS}; do
-        echo "* Updating $PACKAGE..."
+        info "* Updating $PACKAGE..."
         dotnet tool update --local "$PACKAGE" || dotnet tool install --local "$PACKAGE" --create-manifest-if-needed
     done
-    echo "All packages updated"
+    success "All packages updated"
     dotnet tool list
 }
 
@@ -94,32 +99,32 @@ installDotNet
 
 export PATH="$PATH:$HOME/dotnet:$HOME/.dotnet/tools"
 
-echo "HOME: $HOME"
+info "HOME: $HOME"
 
-echo "Installed SDKS:"
+info "Installed SDKS:"
 dotnet --list-sdks || die "Dotnet not found"
 
-echo "Waiting for start"
+info "Waiting for start"
 sleep 30
 
-echo "Listing Nuget Sources"
+info "Listing Nuget Sources"
 dotnet nuget list source || die "Dotnet not found"
 
-echo "Clearing everything"
+info "Clearing everything"
 dotnet nuget locals all --clear || die "Dotnet not found"
 
-echo "Restoring tools"
+info "Restoring tools"
 dotnet tool restore
 
 dotnet tool list || die "Dotnet not found"
 
-echo "Installing tools:"
+info "Installing tools:"
 for PACKAGE in ${TOOLS}; do
-    echo "* Installing $PACKAGE..."
+    info "* Installing $PACKAGE..."
     dotnet tool install --local "$PACKAGE" --create-manifest-if-needed
 done
 
-echo "All tools installed"
+success "All tools installed"
 
 dotnet tool list
 
@@ -129,5 +134,5 @@ while sleep 120; do
 
     update
 
-    echo "Waiting for new packages..."
+    info "Waiting for new packages..."
 done

--- a/certs/generate
+++ b/certs/generate
@@ -1,9 +1,16 @@
 #! /bin/sh
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 BASEDIR=$(dirname "$(readlink -f "$0")")

--- a/clean
+++ b/clean
@@ -1,3 +1,8 @@
 #! /bin/sh
 
-sudo rm -frv /cache/nuget/api.nuget.local/json/* /cache/nuget/funfair.nuget.local/json/* /cache/nuget/funfair-prerelease.nuget.local/jsom/*
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+sudo rm -frv /cache/nuget/api.nuget.local/json/* /cache/nuget/funfair.nuget.local/json/* /cache/nuget/funfair-prerelease.nuget.local/json/* || die "Could not clean nuget cache"

--- a/firewall
+++ b/firewall
@@ -1,58 +1,86 @@
-#! /bin/sh
+#!/bin/bash
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 
-BASEDIR="$(dirname "$(readlink -f "$0")")"
-
-add_ipv4_rule() {
-    range="$1"
-    port="$2"
-    protocol="$3"
-
-    sudo firewall-cmd --permanent --add-rich-rule="rule family=\"ipv4\" source address=\"${range}\" port protocol=\"${protocol}\" port=\"${port}\" accept"
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
 }
 
-add_private_ipv4_rules() {
-    port="$1"
-    protocol="$2"
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
 
-    # RFC1918 private IPv4 ranges.
-    for range in 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16; do
-        add_ipv4_rule "$range" "$port" "$protocol"
+IPV4_PRIVATE_RANGES=(
+    "10.0.0.0/8"
+    "172.16.0.0/12"
+    "192.168.0.0/16"
+)
+
+IPV6_PRIVATE_RANGES=(
+    "fc00::/7"
+    "fe80::/10"
+)
+
+allow_ipv4() {
+    local subnet="$1"
+    local port="$2"
+    local protocol="$3"
+    sudo firewall-cmd --permanent \
+        --add-rich-rule="rule family='ipv4' source address='${subnet}' port port='${port}' protocol='${protocol}' accept"
+}
+
+allow_ipv6() {
+    local subnet="$1"
+    local port="$2"
+    local protocol="$3"
+    sudo firewall-cmd --permanent \
+        --add-rich-rule="rule family='ipv6' source address='${subnet}' port port='${port}' protocol='${protocol}' accept"
+}
+
+open_port_for_private_networks() {
+    local port="$1"
+    local protocol="${2:-tcp}"
+
+    for subnet in "${IPV4_PRIVATE_RANGES[@]}"; do
+        allow_ipv4 "${subnet}" "${port}" "${protocol}"
     done
+
+    for subnet in "${IPV6_PRIVATE_RANGES[@]}"; do
+        allow_ipv6 "${subnet}" "${port}" "${protocol}"
+    done
+
+    sudo firewall-cmd --reload
 }
 
 ## devpkg-nuget
-add_private_ipv4_rules 8081 tcp
-add_private_ipv4_rules 8081 udp
-
+open_port_for_private_networks 8081 tcp
+open_port_for_private_networks 8081 udp
 
 ## devpkg-funfair-release
-add_private_ipv4_rules 8082 tcp
-add_private_ipv4_rules 8082 udp
+open_port_for_private_networks 8082 tcp
+open_port_for_private_networks 8082 udp
 
 ## devpkg-funfair-prerelease
-add_private_ipv4_rules 8083 tcp
-add_private_ipv4_rules 8083 udp
+open_port_for_private_networks 8083 tcp
+open_port_for_private_networks 8083 udp
 
 ## devpkg-npm
-add_private_ipv4_rules 8084 tcp
-add_private_ipv4_rules 8084 udp
+open_port_for_private_networks 8084 tcp
+open_port_for_private_networks 8084 udp
 
 ## devpkg-proxy
-add_private_ipv4_rules 8085 tcp
-add_private_ipv4_rules 8085 udp
+open_port_for_private_networks 8085 tcp
+open_port_for_private_networks 8085 udp
 
 ## devpkg-nginx
-add_private_ipv4_rules 5555 tcp
-add_private_ipv4_rules 5555 udp
-add_private_ipv4_rules 5554 tcp
+open_port_for_private_networks 5555 tcp
+open_port_for_private_networks 5555 udp
+open_port_for_private_networks 5554 tcp
 
 ## devpkg-dozzle
-add_private_ipv4_rules 8080 tcp
+open_port_for_private_networks 8080 tcp
 
-sudo firewall-cmd --reload
+success "Firewall rules applied"

--- a/firewall
+++ b/firewall
@@ -51,8 +51,6 @@ open_port_for_private_networks() {
     for subnet in "${IPV6_PRIVATE_RANGES[@]}"; do
         allow_ipv6 "${subnet}" "${port}" "${protocol}"
     done
-
-    sudo firewall-cmd --reload
 }
 
 ## devpkg-nuget
@@ -83,4 +81,5 @@ open_port_for_private_networks 5554 tcp
 ## devpkg-dozzle
 open_port_for_private_networks 8080 tcp
 
+sudo firewall-cmd --reload || die "Could not reload firewall"
 success "Firewall rules applied"

--- a/install
+++ b/install
@@ -1,39 +1,44 @@
 #! /bin/sh
 
-PROG=$0
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
 BASEDIR="$(dirname "$(readlink -f "$0")")"
-echo "Script Dir: $BASEDIR"
+info "Script Dir: $BASEDIR"
 
-# [ -f "$BASEDIR/.env" ] || die ".env is required"
+info "Updating systemd scripts"
+sed "s:/home/markr/work/credfeto-dev-package-cache:$BASEDIR:g" "systemd-unit/credfeto-package-cache.service" | sudo tee /etc/systemd/system/credfeto-package-cache.service || die "Could not install systemd service"
+sudo cp "$BASEDIR/systemd-unit/credfeto-package-cache.timer" /etc/systemd/system/credfeto-package-cache.timer || die "Could not install systemd timer"
 
-echo "Updating systemd scripts"
-cat "systemd-unit/credfeto-package-cache.service" | sed "s:/home/markr/work/credfeto-dev-package-cache:$BASEDIR:g" | sudo tee /etc/systemd/system/credfeto-package-cache.service
-sudo cp "$BASEDIR/systemd-unit/credfeto-package-cache.timer" /etc/systemd/system/credfeto-package-cache.timer
-
+# shellcheck source=/dev/null
 . /etc/os-release
 if [ "$ID" = "arch" ]; then
   "$BASEDIR/trust-certs.arch"
 elif [ "$ID" = "ubuntu" ]; then
   "$BASEDIR/trust-certs.ubuntu"
 else
-  echo "Unsupported OS - you need to trust the local certs manually"
+  info "Unsupported OS — you need to trust the local certs manually"
 fi
 
-echo "systemd reload"
-sudo systemctl daemon-reload
+info "systemd reload"
+sudo systemctl daemon-reload || die "Could not reload systemd"
 
-echo "Enable credfeto-package-cache.timer"
-sudo systemctl enable credfeto-package-cache.timer
+info "Enable credfeto-package-cache.timer"
+sudo systemctl enable credfeto-package-cache.timer || die "Could not enable timer"
 
-echo "Start credfeto-package-cache.timer"
-sudo systemctl start credfeto-package-cache.timer
+info "Start credfeto-package-cache.timer"
+sudo systemctl start credfeto-package-cache.timer || die "Could not start timer"
 
 "$BASEDIR/update"
 
-echo "Done"
+success "Done"

--- a/mk-k8s
+++ b/mk-k8s
@@ -5,4 +5,14 @@ die() {
     exit 1
 }
 
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
+info "Converting docker-compose.yml to Kubernetes manifests"
 kompose convert -f docker-compose.yml || die "kompose convert failed"
+success "Conversion complete"

--- a/mk-k8s
+++ b/mk-k8s
@@ -1,4 +1,8 @@
 #! /bin/sh
 
-kompose convert -f docker-compose.yml
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
 
+kompose convert -f docker-compose.yml || die "kompose convert failed"

--- a/mk-nuget-config
+++ b/mk-nuget-config
@@ -1,10 +1,16 @@
 #! /bin/sh
 
-PROG=$0
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 BASEDIR="$(dirname "$(readlink -f "$0")")"
@@ -13,5 +19,7 @@ SOURCE="$BASEDIR/nuget.config"
 
 [ -f "$SOURCE" ] || die "Could not find $SOURCE"
 
-rm "$HOME/.nuget/NuGet/NuGet.Config"
-ln -s "$SOURCE" "$HOME/.nuget/NuGet/NuGet.Config"
+info "Linking NuGet config"
+rm "$HOME/.nuget/NuGet/NuGet.Config" || die "Could not remove existing NuGet config"
+ln -s "$SOURCE" "$HOME/.nuget/NuGet/NuGet.Config" || die "Could not link NuGet config"
+success "NuGet config linked"

--- a/nuget-download
+++ b/nuget-download
@@ -1,13 +1,17 @@
 #! /bin/bash
 
-PROG=$0
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 
-BASEDIR="$(dirname "$(readlink -f "$0")")"
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
 
 PACKAGE_ID=
 PACKAGE_VERSION=
@@ -39,7 +43,7 @@ BASE=/cache/nuget/packages/nuget/packages
 LOWER_PACKAGEID=${PACKAGE_ID,,}
 
 PACKAGE_FOLDER=$BASE/$LOWER_PACKAGEID/$PACKAGE_VERSION
-echo "Folder: $PACKAGE_FOLDER"
+info "Folder: $PACKAGE_FOLDER"
 [ -d "$PACKAGE_FOLDER" ] || sudo mkdir -p "$PACKAGE_FOLDER"
 
 NUPKG_PACKAGE_FILENAME=$BASE/$LOWER_PACKAGEID/$PACKAGE_VERSION/$LOWER_PACKAGEID.$PACKAGE_VERSION.nupkg
@@ -55,16 +59,16 @@ if [ ! -f "$NUPKG_PACKAGE_FILENAME" ] || [ ! -f "$NUSPEC_PACKAGE_FILENAME" ]; th
 
     wget --no-verbose --tries=1 "$DOWNLOAD_URL" -O "$WORK_PACKAGE" || die "wget: Could not download"
     [ -f "$WORK_PACKAGE" ] || die "Downloaded file does not exist"
-    unzip -v "$WORK_PACKAGE" *.nuspec
-    unzip "$WORK_PACKAGE" *.nuspec -d "$WORKFOLDER/download"
-    mv $WORKFOLDER/download/*.nuspec "$WORK_NUSPEC"
+    unzip -v "$WORK_PACKAGE" "*.nuspec"
+    unzip "$WORK_PACKAGE" "*.nuspec" -d "$WORKFOLDER/download"
+    mv "$WORKFOLDER"/download/*.nuspec "$WORK_NUSPEC"
 
     sudo mv "$WORK_PACKAGE" "$NUPKG_PACKAGE_FILENAME" || die "Could not update $NUPKG_PACKAGE_FILENAME"
     sudo mv "$WORK_NUSPEC" "$NUSPEC_PACKAGE_FILENAME" || die "Could not update $NUSPEC_PACKAGE_FILENAME"
 
 fi
 
-
 [ -f "$NUPKG_PACKAGE_FILENAME" ] || die "$NUPKG_PACKAGE_FILENAME still does not exist after updating"
 [ -f "$NUSPEC_PACKAGE_FILENAME" ] || die "$NUSPEC_PACKAGE_FILENAME still does not exist after updating"
 
+success "Package $PACKAGE_ID $PACKAGE_VERSION downloaded"

--- a/reinstall
+++ b/reinstall
@@ -1,31 +1,35 @@
 #! /bin/bash
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
 
 exec {lock_fd}>/tmp/devpkg || exit 1
 
-/bin/flock -n "$lock_fd" || { echo "ERROR: flock() failed." >&2; exit 1; }
+/bin/flock -n "$lock_fd" || { printf '\n\033[31m✗\033[0m %s\n' "ERROR: flock() failed." >&2; exit 1; }
 
 git pull
 
-echo "Stopping containers"
+info "Stopping containers"
 sudo docker compose stop && sudo docker compose rm --force
 
 [ -d /cache ] || sudo mkdir /cache
 
-echo "Removing NGINX cache"
+info "Removing NGINX cache"
 sudo rm -fr /cache/nginx
-
 
 [ -d /cache/nginx ] || sudo mkdir /cache/nginx
 [ -d /cache/npm ] || sudo mkdir /cache/npm
 [ -d /cache/nuget ] || sudo mkdir /cache/nuget
-
 
 sudo chown -R 10001:65533 /cache/npm || die "Could not set npm permissions"
 
@@ -33,4 +37,3 @@ sudo docker compose pull || die "Could not pull images"
 sudo docker compose up --no-start || die "Could not build containers"
 
 sudo docker compose up -d --remove-orphans || die "Could not start containers"
-

--- a/restarter/command
+++ b/restarter/command
@@ -1,10 +1,21 @@
 #! /bin/sh
 
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
 info() {
     printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 [ -z "$RESTARTER_TAG" ] && RESTARTER_TAG=devpkg
+
+info "Tag: $RESTARTER_TAG"
 
 while true; do
   info "$RESTARTER_TAG: Sleeping..."

--- a/restarter/command
+++ b/restarter/command
@@ -1,16 +1,15 @@
 #! /bin/sh
 
-echo "Tag: $RESTARTER_TAG"
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
 
 [ -z "$RESTARTER_TAG" ] && RESTARTER_TAG=devpkg
 
-while true; do 
-  echo "$RESTARTER_TAG: Sleeping..."
-  sleep 60;
+while true; do
+  info "$RESTARTER_TAG: Sleeping..."
+  sleep 60
 
-#  echo "$RESTARTER_TAG: Find Unhealthy"
-#  docker ps -q -f health=unhealthy -f "name=$RESTARTER_TAG"
-#
-  echo "$RESTARTER_TAG Restarting unhealthy"
-  docker ps -q -f health=unhealthy -f "name=$RESTARTER_TAG" | xargs --no-run-if-empty docker restart;
+  info "$RESTARTER_TAG: Restarting unhealthy"
+  docker ps -q -f health=unhealthy -f "name=$RESTARTER_TAG" | xargs --no-run-if-empty docker restart
 done

--- a/trust-certs.arch
+++ b/trust-certs.arch
@@ -1,8 +1,23 @@
 #! /bin/sh
 
-sudo trust anchor --store ./certs/api.nuget.local.pem
-sudo trust anchor --store ./certs/funfair.nuget.local.pem
-sudo trust anchor --store ./certs/funfair-prerelease.nuget.local.pem
-sudo trust anchor --store ./certs/npm.local.pem
-sudo trust anchor --store ./certs/builds.dotnet.local.pem
-sudo trust extract-compat
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
+info "Trusting certificates (Arch)"
+sudo trust anchor --store ./certs/api.nuget.local.pem || die "Could not trust api.nuget.local.pem"
+sudo trust anchor --store ./certs/funfair.nuget.local.pem || die "Could not trust funfair.nuget.local.pem"
+sudo trust anchor --store ./certs/funfair-prerelease.nuget.local.pem || die "Could not trust funfair-prerelease.nuget.local.pem"
+sudo trust anchor --store ./certs/npm.local.pem || die "Could not trust npm.local.pem"
+sudo trust anchor --store ./certs/builds.dotnet.local.pem || die "Could not trust builds.dotnet.local.pem"
+sudo trust extract-compat || die "Could not extract compat"
+success "Certificates trusted"

--- a/trust-certs.ubuntu
+++ b/trust-certs.ubuntu
@@ -1,4 +1,19 @@
 #! /bin/sh
 
-sudo cp ./certs/*.crt /usr/local/share/ca-certificates/
-sudo update-ca-certificates
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
+info "Trusting certificates (Ubuntu)"
+sudo cp ./certs/*.crt /usr/local/share/ca-certificates/ || die "Could not copy certificates"
+sudo update-ca-certificates || die "Could not update CA certificates"
+success "Certificates trusted"

--- a/update
+++ b/update
@@ -1,9 +1,16 @@
 #! /bin/sh
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 BASEDIR="$(dirname "$(readlink -f "$0")")"
@@ -37,12 +44,12 @@ sudo chown -R 1654:1654 /cache/proxy || die "Could not set proxy permissions"
 sudo chown -R 998:998 /cache/downloads || die "Could not set cache permissions"
 sudo chown -R 998:998 /cache/dotnet || die "Could not set cache permissions"
 
-chmod a+r "$BASEDIR/certs/*.pfx"
+chmod a+r "$BASEDIR"/certs/*.pfx || die "Could not set cert permissions"
 
 export COMPOSE_BAKE=true
 
 if [ ! -f "$BASEDIR/certs/dh.pem" ]; then
-  echo "Generating PFS"
+  info "Generating PFS"
   openssl dhparam -out "$BASEDIR/certs/dh.pem" 4096
 fi
 
@@ -92,23 +99,9 @@ sudo docker volume create \
 sudo docker volume create \
   --opt type=none \
   --opt o=bind \
-  --opt device=/cache/npm/storage \
-  cache_npm_storage
-
-sudo docker volume create \
-  --opt type=none \
-  --opt o=bind \
-  --opt device=/cache/npm/storage \
-  cache_npm_storage
-
-sudo docker volume create \
-  --opt type=none \
-  --opt o=bind \
   --opt device=/cache/nginx \
   cache_nginx
 
 sudo docker compose pull || die "Could not pull images"
 
 sudo docker compose up -d --remove-orphans || die "Could not start containers"
-
-


### PR DESCRIPTION
## Summary

- Syncs `ai/global/` instruction files from cs-template (was missing entirely)
- Fixes `chmod` glob quoting bug in `update` script (`*.pfx` was inside quotes so never expanded)
- Standardises `die()`/`success()`/`info()` output helpers across all shell scripts
- Rewrites `firewall` to use standard `allow_ipv4`/`allow_ipv6`/`open_port_for_private_networks` helpers with IPv6 support
- Removes duplicate `cache_npm_storage` volume create (appeared 3 times)
- Fixes typo `jsom` → `json` in `clean`
- Fixes pre-existing shellcheck warnings in `cache/install-dotnet`
- Raises #10 for remaining shellcheck work

## Test plan

- [ ] Verify `shellcheck` passes on all modified scripts
- [ ] Verify `checkbashisms` passes on all `#!/bin/sh` scripts
- [ ] Run `update` on a target machine and confirm certs are chmod'd correctly
- [ ] Run `firewall` and confirm IPv4 and IPv6 rules are applied

Closes #8
Closes #9